### PR TITLE
Do not use /home for installing root services

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-DIR="/home/$USERNAME/.local/bin"
+DIR="/usr/local/bin"
 
 if [ ! -d "$DIR" ]; then
   echo "$DIRECTORY does not exist..."
@@ -16,9 +16,12 @@ fi
 
 # Copy files
 cp $PWD/pp-to-amd-epp.service /etc/systemd/system/
-cp $PWD/pp-to-amd-epp /home/$USERNAME/.local/bin
+cp $PWD/pp-to-amd-epp /usr/local/bin
 
-# Replace user directory in systemd service file
-sed -i "s#ExecStart=/home/user/.local/bin/pp-to-amd-epp#ExecStart=/home/$USERNAME/.local/bin/pp-to-amd-epp#g" /etc/systemd/system/pp-to-amd-epp.service
+# Set permissions
+chown root:root /usr/local/bin/pp-to-amd-epp /etc/systemd/system/pp-to-amd-epp.service
+chmod 655 /usr/local/bin/pp-to-amd-epp /etc/systemd/system/pp-to-amd-epp.service
+chmod +x /usr/local/bin/pp-to-amd-epp
+
 # Enable systemd service
 systemctl enable --now pp-to-amd-epp.service

--- a/pp-to-amd-epp.service
+++ b/pp-to-amd-epp.service
@@ -7,7 +7,7 @@ After=power-profiles-daemon.service
 Type=simple
 Restart=on-failure
 User=root
-ExecStart=/home/user/.local/bin/pp-to-amd-epp
+ExecStart=/usr/local/bin/pp-to-amd-epp
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Any script that runs as a service with root permissions shouldn't be located in the user home directory. 
This a huge security hole because by it is possible to edit the script service without having to have root permissions and effecting a service that does have root access. Basically bypassing .
The likelihood of a attacker finding such custom script is probably really small but not zero so this should just be avoided. 
This PR changes the install script to use /usr/local/bin and the service file to run from that.